### PR TITLE
Lock free, concurrent safe state management data structure 

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ touch .env
 
 ```bash
 RPCUrl=https://<rpc-node>
+WSUrl=wss://<rpc-node>
 MemPoolPollingPeriod=1000
 PendingTxEntryTopic=pending_pool_entry
 PendingTxExitTopic=pending_pool_exit
@@ -116,6 +117,7 @@ Port=7000
 Environment Variable | Interpretation
 --- | ---
 RPCUrl | `txpool` RPC API enabled Ethereum Node's URI
+WSUrl | To be used for listening to newly mined block headers
 MemPoolPollingPeriod | RPC node's mempool to be checked every `X` milliseconds
 PendingTxEntryTopic | Whenever tx enters pending pool, it'll be published on Redis topic `t`
 PendingTxExitTopic | Whenever tx leaves pending pool, it'll be published on Redis topic `t`

--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -124,7 +124,6 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 		IsPruning:         false,
 		AddTxChan:         make(chan data.AddRequest, 1),
 		RemoveTxChan:      make(chan data.RemovedUnstuckTx, 1),
-		RemoveTxsChan:     make(chan data.RemoveTxsFromQueuedPool, 1),
 		TxExistsChan:      make(chan data.ExistsRequest, 1),
 		GetTxChan:         make(chan data.GetRequest, 1),
 		CountTxsChan:      make(chan data.CountRequest, 1),
@@ -141,7 +140,9 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 
 	// Starting pool life cycle manager go routine
 	go pool.Pending.Start(ctx)
+	go pool.Pending.Prune(ctx)
 	go pool.Queued.Start(ctx)
+	go pool.Queued.Prune(ctx)
 
 	// Passed this mempool handle to graphql query resolver
 	if err := graph.InitMemPool(pool); err != nil {

--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -107,7 +107,6 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 		IsPruning:         false,
 		AddTxChan:         make(chan data.AddRequest, 1),
 		RemoveTxChan:      make(chan data.RemoveRequest, 1),
-		RemoveTxsChan:     make(chan data.RemoveTxsFromPendingPool, 1),
 		TxExistsChan:      make(chan data.ExistsRequest, 1),
 		GetTxChan:         make(chan data.GetRequest, 1),
 		CountTxsChan:      make(chan data.CountRequest, 1),

--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -3,6 +3,7 @@ package bootup
 import (
 	"context"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -102,6 +103,8 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 		Transactions:      make(map[common.Hash]*data.MemPoolTx),
 		AscTxsByGasPrice:  make(data.MemPoolTxsAsc, 0, 1024),
 		DescTxsByGasPrice: make(data.MemPoolTxsDesc, 0, 1024),
+		Lock:              &sync.Mutex{},
+		IsPruning:         false,
 		AddTxChan:         make(chan data.AddRequest, 1),
 		RemoveTxChan:      make(chan data.RemoveRequest, 1),
 		RemoveTxsChan:     make(chan data.RemoveTxsFromPendingPool, 1),

--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -146,7 +146,7 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 
 	// Block head listener & pending pool pruner
 	// talks over this buffered channel
-	commChan := make(chan *listen.CaughtTx, 1024)
+	commChan := make(chan listen.CaughtTxs, 1024)
 
 	// Starting pool life cycle manager go routine
 	go pool.Pending.Start(ctx)

--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -111,6 +111,8 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 			ListTxsChan:       make(chan data.ListRequest, 1),
 			PubSub:            _redis,
 			RPC:               client,
+			LastPruned:        time.Now().UTC(),
+			PruneAfter:        time.Duration(2) * time.Second,
 		},
 		Queued: &data.QueuedPool{
 			Transactions:      make(map[common.Hash]*data.MemPoolTx),

--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -112,7 +112,7 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 			PubSub:            _redis,
 			RPC:               client,
 			LastPruned:        time.Now().UTC(),
-			PruneAfter:        time.Duration(2) * time.Second,
+			PruneAfter:        config.GetPendingPoolPruningDelay(),
 		},
 		Queued: &data.QueuedPool{
 			Transactions:      make(map[common.Hash]*data.MemPoolTx),

--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -121,6 +121,8 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 		Transactions:      make(map[common.Hash]*data.MemPoolTx),
 		AscTxsByGasPrice:  make(data.MemPoolTxsAsc, 0, 1024),
 		DescTxsByGasPrice: make(data.MemPoolTxsDesc, 0, 1024),
+		Lock:              &sync.RWMutex{},
+		IsPruning:         false,
 		AddTxChan:         make(chan data.AddRequest, 1),
 		RemoveTxChan:      make(chan data.RemovedUnstuckTx, 1),
 		RemoveTxsChan:     make(chan data.RemoveTxsFromQueuedPool, 1),

--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -3,7 +3,6 @@ package bootup
 import (
 	"context"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -120,7 +119,6 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 		Transactions:      make(map[common.Hash]*data.MemPoolTx),
 		AscTxsByGasPrice:  make(data.MemPoolTxsAsc, 0, 1024),
 		DescTxsByGasPrice: make(data.MemPoolTxsDesc, 0, 1024),
-		Lock:              &sync.RWMutex{},
 		AddTxChan:         make(chan data.AddRequest, 1),
 		RemoveTxChan:      make(chan data.RemovedUnstuckTx, 1),
 		TxExistsChan:      make(chan data.ExistsRequest, 1),

--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -103,7 +103,7 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 		Transactions:      make(map[common.Hash]*data.MemPoolTx),
 		AscTxsByGasPrice:  make(data.MemPoolTxsAsc, 0, 1024),
 		DescTxsByGasPrice: make(data.MemPoolTxsDesc, 0, 1024),
-		Lock:              &sync.Mutex{},
+		Lock:              &sync.RWMutex{},
 		IsPruning:         false,
 		AddTxChan:         make(chan data.AddRequest, 1),
 		RemoveTxChan:      make(chan data.RemoveRequest, 1),

--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -175,6 +175,7 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 
 	return &data.Resource{
 		RPCClient: client,
+		WSClient:  wsClient,
 		Pool:      pool,
 		Redis:     _redis,
 		StartedAt: time.Now().UTC(),

--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -139,8 +139,9 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 		Queued:  queuedPool,
 	}
 
-	// Starting pending pool life cycle manager go routine
+	// Starting pool life cycle manager go routine
 	go pool.Pending.Start(ctx)
+	go pool.Queued.Start(ctx)
 
 	// Passed this mempool handle to graphql query resolver
 	if err := graph.InitMemPool(pool); err != nil {

--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -104,14 +104,13 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 		DescTxsByGasPrice: make(data.MemPoolTxsDesc, 0, 1024),
 		AddTxChan:         make(chan data.AddRequest, 1),
 		RemoveTxChan:      make(chan data.RemoveRequest, 1),
+		RemoveTxsChan:     make(chan data.RemoveTxsFromPendingPool, 1),
 		TxExistsChan:      make(chan data.ExistsRequest, 1),
 		GetTxChan:         make(chan data.GetRequest, 1),
 		CountTxsChan:      make(chan data.CountRequest, 1),
 		ListTxsChan:       make(chan data.ListRequest, 1),
 		PubSub:            _redis,
 		RPC:               client,
-		LastPruned:        time.Now().UTC(),
-		PruneAfter:        config.GetPendingPoolPruningDelay(),
 	}
 
 	// initialising queued pool
@@ -121,6 +120,7 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 		DescTxsByGasPrice: make(data.MemPoolTxsDesc, 0, 1024),
 		AddTxChan:         make(chan data.AddRequest, 1),
 		RemoveTxChan:      make(chan data.RemovedUnstuckTx, 1),
+		RemoveTxsChan:     make(chan data.RemoveTxsFromQueuedPool, 1),
 		TxExistsChan:      make(chan data.ExistsRequest, 1),
 		GetTxChan:         make(chan data.GetRequest, 1),
 		CountTxsChan:      make(chan data.CountRequest, 1),
@@ -128,8 +128,6 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 		PubSub:            _redis,
 		RPC:               client,
 		PendingPool:       pendingPool,
-		LastPruned:        time.Now().UTC(),
-		PruneAfter:        config.GetQueuedPoolPruningDelay(),
 	}
 
 	pool := &data.MemPool{

--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -45,7 +45,11 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 	}
 
 	client, err := rpc.DialContext(ctx, config.Get("RPCUrl"))
+	if err != nil {
+		return nil, err
+	}
 
+	wsClient, err := ethclient.DialContext(ctx, config.Get("WSUrl"))
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +156,7 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 	go pool.Queued.Prune(ctx)
 	// Listens for new block headers & informs 👆 (a) for pruning
 	// txs which can be/ need to be
-	go listen.SubscribeHead(ctx, ethclient.NewClient(client), commChan)
+	go listen.SubscribeHead(ctx, wsClient, commChan)
 
 	// Passed this mempool handle to graphql query resolver
 	if err := graph.InitMemPool(pool); err != nil {

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"runtime"
 	"strconv"
+	"time"
 
 	"github.com/spf13/viper"
 )
@@ -57,6 +58,21 @@ func GetMemPoolPollingPeriod() uint64 {
 	}
 
 	return _period
+
+}
+
+// GetPendingPoolPruningDelay - Only attempt to prune pending pool txs
+// after this delay ( expecting input from user in terms of milliseconds )
+func GetPendingPoolPruningDelay() time.Duration {
+
+	period := Get("PendingPoolPruingDelay")
+
+	_period, err := strconv.ParseUint(period, 10, 64)
+	if err != nil {
+		return time.Duration(1000) * time.Millisecond
+	}
+
+	return time.Duration(_period) * time.Millisecond
 
 }
 

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"runtime"
 	"strconv"
-	"time"
 
 	"github.com/spf13/viper"
 )
@@ -58,36 +57,6 @@ func GetMemPoolPollingPeriod() uint64 {
 	}
 
 	return _period
-
-}
-
-// GetPendingPoolPruningDelay - Only attempt to prune pending pool txs
-// after this delay ( expecting input from user in terms of milliseconds )
-func GetPendingPoolPruningDelay() time.Duration {
-
-	period := Get("PendingPoolPruingDelay")
-
-	_period, err := strconv.ParseUint(period, 10, 64)
-	if err != nil {
-		return time.Duration(1000) * time.Millisecond
-	}
-
-	return time.Duration(_period) * time.Millisecond
-
-}
-
-// GetQueuedPoolPruningDelay - Only attempt to prune queued pool txs
-// after this delay ( expecting input from user in terms of milliseconds )
-func GetQueuedPoolPruningDelay() time.Duration {
-
-	period := Get("QueuedPoolPruingDelay")
-
-	_period, err := strconv.ParseUint(period, 10, 64)
-	if err != nil {
-		return time.Duration(1000) * time.Millisecond
-	}
-
-	return time.Duration(_period) * time.Millisecond
 
 }
 

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -76,6 +76,21 @@ func GetPendingPoolPruningDelay() time.Duration {
 
 }
 
+// GetQueuedPoolPruningDelay - Only attempt to prune queued pool txs
+// after this delay ( expecting input from user in terms of milliseconds )
+func GetQueuedPoolPruningDelay() time.Duration {
+
+	period := Get("QueuedPoolPruingDelay")
+
+	_period, err := strconv.ParseUint(period, 10, 64)
+	if err != nil {
+		return time.Duration(1000) * time.Millisecond
+	}
+
+	return time.Duration(_period) * time.Millisecond
+
+}
+
 // GetPendingTxEntryPublishTopic - Read provided topic name from `.env` file
 // where newly added pending pool tx(s) to be published
 func GetPendingTxEntryPublishTopic() string {

--- a/app/data/common.go
+++ b/app/data/common.go
@@ -25,16 +25,21 @@ func IsPresentInCurrentPool(txs map[string]map[string]*MemPoolTx, txHash common.
 
 	var present bool
 
-	for _, vOuter := range txs {
+	// @note ⭐️
+	//
+	// Don't copy value reference here, directly pass it during
+	// function invokation, while accessing value using field `k`
+	for k := range txs {
 
 		func(txs map[string]*MemPoolTx) {
 
 			wp.Submit(func() {
 
-				for _, vInner := range vOuter {
+				// Same as ⭐️
+				for k := range txs {
 
-					if vInner.Hash == txHash {
-						commChan <- present
+					if txs[k].Hash == txHash {
+						commChan <- true
 						break
 					}
 
@@ -42,7 +47,7 @@ func IsPresentInCurrentPool(txs map[string]map[string]*MemPoolTx, txHash common.
 
 			})
 
-		}(vOuter)
+		}(txs[k])
 
 	}
 

--- a/app/data/interaction.go
+++ b/app/data/interaction.go
@@ -33,6 +33,15 @@ type RemoveTxsFromPendingPool struct {
 	ResponseChan chan uint64
 }
 
+// RemoveTxsFromQueuedPool - For updating local queued pool state, request of
+// this form to be sent to pool manager over channel, where it'll check which txs
+// are likely to be unstuck & has moved to pending pool
+type RemoveTxsFromQueuedPool struct {
+	Pending      map[string]map[string]*MemPoolTx
+	Queued       map[string]map[string]*MemPoolTx
+	ResponseChan chan uint64
+}
+
 // ExistsRequest - Checking whether tx is present in pool or not
 type ExistsRequest struct {
 	Tx           common.Hash

--- a/app/data/interaction.go
+++ b/app/data/interaction.go
@@ -1,0 +1,37 @@
+package data
+
+import "github.com/ethereum/go-ethereum/common"
+
+// AddRequest - For adding new tx into pool
+type AddRequest struct {
+	Tx           *MemPoolTx
+	ResponseChan chan bool
+}
+
+// RemoveRequest - For removing existing tx into pool
+type RemoveRequest struct {
+	TxStat       *TxStatus
+	ResponseChan chan bool
+}
+
+// ExistsRequest - Checking whether tx is present in pool or not
+type ExistsRequest struct {
+	Tx           common.Hash
+	ResponseChan chan bool
+}
+
+// GetRequest - Obtaining reference to existing tx in pool
+type GetRequest struct {
+	Tx           common.Hash
+	ResponseChan chan *MemPoolTx
+}
+
+// CountRequest - Getting #-of txs present in pool
+type CountRequest struct {
+	ResponseChan chan uint64
+}
+
+// ListRequest - Listing all txs in pool
+type ListRequest struct {
+	ResponseChan chan TxList
+}

--- a/app/data/interaction.go
+++ b/app/data/interaction.go
@@ -2,6 +2,11 @@ package data
 
 import "github.com/ethereum/go-ethereum/common"
 
+const (
+	ASC = iota
+	DESC
+)
+
 // AddRequest - For adding new tx into pool
 type AddRequest struct {
 	Tx           *MemPoolTx
@@ -33,5 +38,6 @@ type CountRequest struct {
 
 // ListRequest - Listing all txs in pool
 type ListRequest struct {
+	Order        int
 	ResponseChan chan []*MemPoolTx
 }

--- a/app/data/interaction.go
+++ b/app/data/interaction.go
@@ -2,9 +2,18 @@ package data
 
 import "github.com/ethereum/go-ethereum/common"
 
+// Sorting direction representation
 const (
 	ASC = iota
 	DESC
+)
+
+// When submitting async request for pruning pending/ queued
+// pool, immediate response to be sent to client in any of these form(s)
+const (
+	EMPTY = iota
+	PRUNING
+	SCHEDULED
 )
 
 // AddRequest - For adding new tx into pool
@@ -30,7 +39,7 @@ type RemovedUnstuckTx struct {
 // from pending pool, this request to be sent to pending pool manager
 type RemoveTxsFromPendingPool struct {
 	Txs          map[string]map[string]*MemPoolTx
-	ResponseChan chan bool
+	ResponseChan chan int
 }
 
 // RemoveTxsFromQueuedPool - For updating local queued pool state, request of

--- a/app/data/interaction.go
+++ b/app/data/interaction.go
@@ -19,6 +19,13 @@ type RemoveRequest struct {
 	ResponseChan chan bool
 }
 
+// RemovedUnstuckTx - Remove unstuck tx from queued pool, request to be
+// sent in this form
+type RemovedUnstuckTx struct {
+	Hash         common.Hash
+	ResponseChan chan *MemPoolTx
+}
+
 // ExistsRequest - Checking whether tx is present in pool or not
 type ExistsRequest struct {
 	Tx           common.Hash

--- a/app/data/interaction.go
+++ b/app/data/interaction.go
@@ -48,7 +48,7 @@ type RemoveTxsFromPendingPool struct {
 type RemoveTxsFromQueuedPool struct {
 	Pending      map[string]map[string]*MemPoolTx
 	Queued       map[string]map[string]*MemPoolTx
-	ResponseChan chan uint64
+	ResponseChan chan int
 }
 
 // ExistsRequest - Checking whether tx is present in pool or not

--- a/app/data/interaction.go
+++ b/app/data/interaction.go
@@ -33,5 +33,5 @@ type CountRequest struct {
 
 // ListRequest - Listing all txs in pool
 type ListRequest struct {
-	ResponseChan chan TxList
+	ResponseChan chan []*MemPoolTx
 }

--- a/app/data/interaction.go
+++ b/app/data/interaction.go
@@ -26,6 +26,13 @@ type RemovedUnstuckTx struct {
 	ResponseChan chan *MemPoolTx
 }
 
+// RemoveTxsRequest - For checking which txs can be removed
+// from pending pool, this request to be sent to pending pool manager
+type RemoveTxsFromPendingPool struct {
+	Txs          map[string]map[string]*MemPoolTx
+	ResponseChan chan uint64
+}
+
 // ExistsRequest - Checking whether tx is present in pool or not
 type ExistsRequest struct {
 	Tx           common.Hash

--- a/app/data/interaction.go
+++ b/app/data/interaction.go
@@ -30,7 +30,7 @@ type RemovedUnstuckTx struct {
 // from pending pool, this request to be sent to pending pool manager
 type RemoveTxsFromPendingPool struct {
 	Txs          map[string]map[string]*MemPoolTx
-	ResponseChan chan uint64
+	ResponseChan chan bool
 }
 
 // RemoveTxsFromQueuedPool - For updating local queued pool state, request of

--- a/app/data/pending.go
+++ b/app/data/pending.go
@@ -141,6 +141,9 @@ func (p *PendingPool) Start(ctx context.Context) {
 				// for concurrently checking status of tx(s)
 				wp := workerpool.New(config.GetConcurrencyFactor())
 
+				// -- Critical section begins
+				p.Lock.Lock()
+
 				txs := p.DescTxsByGasPrice.get()
 				txCount := uint64(len(txs))
 				commChan := make(chan *TxStatus, txCount)
@@ -193,6 +196,9 @@ func (p *PendingPool) Start(ctx context.Context) {
 					}(txs[i])
 
 				}
+
+				p.Lock.Unlock()
+				// -- ends here
 
 				buffer := make([]*TxStatus, 0, txCount)
 

--- a/app/data/pending.go
+++ b/app/data/pending.go
@@ -305,6 +305,14 @@ func (p *PendingPool) Start(ctx context.Context) {
 				// -- Safe reading begins
 				p.Lock.RLock()
 
+				// If empty, just return nil
+				if p.AscTxsByGasPrice.len() == 0 {
+					req.ResponseChan <- nil
+
+					p.Lock.RUnlock()
+					break
+				}
+
 				copied := make([]*MemPoolTx, p.AscTxsByGasPrice.len())
 				copy(copied, p.AscTxsByGasPrice.get())
 
@@ -318,6 +326,14 @@ func (p *PendingPool) Start(ctx context.Context) {
 			if req.Order == DESC {
 				// -- Safe reading begins
 				p.Lock.RLock()
+
+				// If empty, just return nil
+				if p.DescTxsByGasPrice.len() == 0 {
+					req.ResponseChan <- nil
+
+					p.Lock.RUnlock()
+					break
+				}
 
 				copied := make([]*MemPoolTx, p.DescTxsByGasPrice.len())
 				copy(copied, p.DescTxsByGasPrice.get())
@@ -384,14 +400,18 @@ func (p *PendingPool) DuplicateTxs(hash common.Hash) []*MemPoolTx {
 		return nil
 	}
 
-	// Attempting to concurrently checking which txs are duplicate
-	// of a given tx hash
-	wp := workerpool.New(config.GetConcurrencyFactor())
-
 	txs := p.DescListTxs()
+	if txs == nil {
+		return nil
+	}
+
 	txCount := uint64(len(txs))
 	commChan := make(chan *MemPoolTx, txCount)
 	result := make([]*MemPoolTx, 0, txCount)
+
+	// Attempting to concurrently checking which txs are duplicate
+	// of a given tx hash
+	wp := workerpool.New(config.GetConcurrencyFactor())
 
 	for i := 0; i < len(txs); i++ {
 
@@ -477,12 +497,16 @@ func (p *PendingPool) TopXWithLowGasPrice(x uint64) []*MemPoolTx {
 // specified address
 func (p *PendingPool) SentFrom(address common.Address) []*MemPoolTx {
 
-	wp := workerpool.New(config.GetConcurrencyFactor())
-
 	txs := p.DescListTxs()
+	if txs == nil {
+		return nil
+	}
+
 	txCount := uint64(len(txs))
 	commChan := make(chan *MemPoolTx, txCount)
 	result := make([]*MemPoolTx, 0, txCount)
+
+	wp := workerpool.New(config.GetConcurrencyFactor())
 
 	for i := 0; i < len(txs); i++ {
 
@@ -534,12 +558,16 @@ func (p *PendingPool) SentFrom(address common.Address) []*MemPoolTx {
 // specified address
 func (p *PendingPool) SentTo(address common.Address) []*MemPoolTx {
 
-	wp := workerpool.New(config.GetConcurrencyFactor())
-
 	txs := p.DescListTxs()
+	if txs == nil {
+		return nil
+	}
+
 	txCount := uint64(len(txs))
 	commChan := make(chan *MemPoolTx, txCount)
 	result := make([]*MemPoolTx, 0, txCount)
+
+	wp := workerpool.New(config.GetConcurrencyFactor())
 
 	for i := 0; i < len(txs); i++ {
 
@@ -591,12 +619,16 @@ func (p *PendingPool) SentTo(address common.Address) []*MemPoolTx {
 // living in mempool for more than or equals to `X` time unit
 func (p *PendingPool) OlderThanX(x time.Duration) []*MemPoolTx {
 
-	wp := workerpool.New(config.GetConcurrencyFactor())
-
 	txs := p.DescListTxs()
+	if txs == nil {
+		return nil
+	}
+
 	txCount := uint64(len(txs))
 	commChan := make(chan *MemPoolTx, txCount)
 	result := make([]*MemPoolTx, 0, txCount)
+
+	wp := workerpool.New(config.GetConcurrencyFactor())
 
 	for i := 0; i < len(txs); i++ {
 
@@ -648,12 +680,16 @@ func (p *PendingPool) OlderThanX(x time.Duration) []*MemPoolTx {
 // living in mempool for less than or equals to `X` time unit
 func (p *PendingPool) FresherThanX(x time.Duration) []*MemPoolTx {
 
-	wp := workerpool.New(config.GetConcurrencyFactor())
-
 	txs := p.DescListTxs()
+	if txs == nil {
+		return nil
+	}
+
 	txCount := uint64(len(txs))
 	commChan := make(chan *MemPoolTx, txCount)
 	result := make([]*MemPoolTx, 0, txCount)
+
+	wp := workerpool.New(config.GetConcurrencyFactor())
 
 	for i := 0; i < len(txs); i++ {
 

--- a/app/data/pending.go
+++ b/app/data/pending.go
@@ -3,6 +3,7 @@ package data
 import (
 	"context"
 	"log"
+	"runtime"
 	"sync"
 	"time"
 
@@ -411,7 +412,7 @@ func (p *PendingPool) DuplicateTxs(hash common.Hash) []*MemPoolTx {
 
 	// Attempting to concurrently checking which txs are duplicate
 	// of a given tx hash
-	wp := workerpool.New(config.GetConcurrencyFactor())
+	wp := workerpool.New(runtime.NumCPU())
 
 	for i := 0; i < len(txs); i++ {
 
@@ -506,7 +507,7 @@ func (p *PendingPool) SentFrom(address common.Address) []*MemPoolTx {
 	commChan := make(chan *MemPoolTx, txCount)
 	result := make([]*MemPoolTx, 0, txCount)
 
-	wp := workerpool.New(config.GetConcurrencyFactor())
+	wp := workerpool.New(runtime.NumCPU())
 
 	for i := 0; i < len(txs); i++ {
 
@@ -567,7 +568,7 @@ func (p *PendingPool) SentTo(address common.Address) []*MemPoolTx {
 	commChan := make(chan *MemPoolTx, txCount)
 	result := make([]*MemPoolTx, 0, txCount)
 
-	wp := workerpool.New(config.GetConcurrencyFactor())
+	wp := workerpool.New(runtime.NumCPU())
 
 	for i := 0; i < len(txs); i++ {
 
@@ -628,7 +629,7 @@ func (p *PendingPool) OlderThanX(x time.Duration) []*MemPoolTx {
 	commChan := make(chan *MemPoolTx, txCount)
 	result := make([]*MemPoolTx, 0, txCount)
 
-	wp := workerpool.New(config.GetConcurrencyFactor())
+	wp := workerpool.New(runtime.NumCPU())
 
 	for i := 0; i < len(txs); i++ {
 
@@ -689,7 +690,7 @@ func (p *PendingPool) FresherThanX(x time.Duration) []*MemPoolTx {
 	commChan := make(chan *MemPoolTx, txCount)
 	result := make([]*MemPoolTx, 0, txCount)
 
-	wp := workerpool.New(config.GetConcurrencyFactor())
+	wp := workerpool.New(runtime.NumCPU())
 
 	for i := 0; i < len(txs); i++ {
 

--- a/app/data/pending.go
+++ b/app/data/pending.go
@@ -271,7 +271,17 @@ func (p *PendingPool) Prune(ctx context.Context, commChan chan listen.CaughtTxs)
 
 						for i := 0; i < len(prunables); i++ {
 
-							func(tx *MemPoolTx) {
+							func(idx int, tx *MemPoolTx) {
+
+								// First element of this list is always
+								// which tx got mined in block, so it's confirmed
+								//
+								// We might find some associated tx(s), which will non-zero-indexed
+								// elements, so it's safe to avoid `IsDropped` check for first txHash
+								if idx == 0 {
+									internalChan <- &TxStatus{Hash: tx.Hash, Status: CONFIRMED}
+									return
+								}
 
 								wp.Submit(func() {
 
@@ -289,7 +299,7 @@ func (p *PendingPool) Prune(ctx context.Context, commChan chan listen.CaughtTxs)
 
 								})
 
-							}(prunables[i])
+							}(i, prunables[i])
 
 						}
 

--- a/app/data/pending.go
+++ b/app/data/pending.go
@@ -255,8 +255,9 @@ func (p *PendingPool) Prune(ctx context.Context, commChan chan *listen.CaughtTx)
 			if prunables == nil {
 				break
 			}
+			var expected uint64 = uint64(len(prunables))
 
-			for i := 0; i < len(prunables); i++ {
+			for i := 0; i < int(expected); i++ {
 
 				func(tx *MemPoolTx) {
 
@@ -281,11 +282,12 @@ func (p *PendingPool) Prune(ctx context.Context, commChan chan *listen.CaughtTx)
 			}
 
 			var (
+				received           uint64
 				droppedOrConfirmed uint64
 				marked             uint64
 			)
 
-			// Waiting for all go routines to finish
+			// Waiting for all workers to finish
 			for v := range internalChan {
 
 				if v.Status == CONFIRMED || v.Status == DROPPED {
@@ -302,6 +304,11 @@ func (p *PendingPool) Prune(ctx context.Context, commChan chan *listen.CaughtTx)
 						}
 					}
 
+				}
+
+				received++
+				if received >= expected {
+					break
 				}
 
 			}

--- a/app/data/pending.go
+++ b/app/data/pending.go
@@ -20,6 +20,36 @@ type PendingPool struct {
 	AscTxsByGasPrice  TxList
 	DescTxsByGasPrice TxList
 	Lock              *sync.RWMutex
+	AddTxChan         chan *MemPoolTx
+	RemoveTxChan      chan *TxStatus
+	TxExistsChan      chan common.Hash
+	GetTxChan         chan common.Hash
+	CountTxsChan      chan interface{}
+	ListTxsChan       chan interface{}
+}
+
+// Start - This method is supposed to be run as an independent
+// go routine, maintaining pending pool state, through out its life time
+func (p *PendingPool) Start(ctx context.Context) {
+
+	for {
+
+		select {
+
+		case <-ctx.Done():
+			return
+
+		case <-p.AddTxChan:
+		case <-p.RemoveTxChan:
+		case <-p.TxExistsChan:
+		case <-p.GetTxChan:
+		case <-p.CountTxsChan:
+		case <-p.ListTxsChan:
+
+		}
+
+	}
+
 }
 
 // Get - Given tx hash, attempts to find out tx in pending pool, if any

--- a/app/data/pending.go
+++ b/app/data/pending.go
@@ -305,7 +305,10 @@ func (p *PendingPool) Start(ctx context.Context) {
 				// -- Safe reading begins
 				p.Lock.RLock()
 
-				req.ResponseChan <- p.AscTxsByGasPrice.get()
+				copied := make([]*MemPoolTx, p.AscTxsByGasPrice.len())
+				copy(copied, p.AscTxsByGasPrice.get())
+
+				req.ResponseChan <- copied
 
 				p.Lock.RUnlock()
 				// -- ends
@@ -316,7 +319,10 @@ func (p *PendingPool) Start(ctx context.Context) {
 				// -- Safe reading begins
 				p.Lock.RLock()
 
-				req.ResponseChan <- p.DescTxsByGasPrice.get()
+				copied := make([]*MemPoolTx, p.DescTxsByGasPrice.len())
+				copy(copied, p.DescTxsByGasPrice.get())
+
+				req.ResponseChan <- copied
 
 				p.Lock.RUnlock()
 				// -- ends

--- a/app/data/pending.go
+++ b/app/data/pending.go
@@ -300,6 +300,7 @@ func (p *PendingPool) Prune(ctx context.Context) {
 			var (
 				received           uint64
 				droppedOrConfirmed uint64
+				marked             uint64
 			)
 
 			// Waiting for all go routines to finish
@@ -312,8 +313,10 @@ func (p *PendingPool) Prune(ctx context.Context) {
 					if p.Remove(ctx, v) {
 						droppedOrConfirmed++
 
-						if droppedOrConfirmed%10 == 0 {
+						if droppedOrConfirmed > marked && droppedOrConfirmed%10 == 0 {
 							log.Printf("[➖] Removed 10 tx(s) from pending tx pool\n")
+
+							marked = droppedOrConfirmed
 						}
 					}
 

--- a/app/data/pending.go
+++ b/app/data/pending.go
@@ -112,6 +112,7 @@ func (p *PendingPool) Start(ctx context.Context) {
 		case req := <-p.RemoveTxsChan:
 
 			if p.DescTxsByGasPrice.len() == 0 {
+				req.ResponseChan <- 0
 				break
 			}
 
@@ -204,6 +205,7 @@ func (p *PendingPool) Start(ctx context.Context) {
 			//
 			// Nothing has changed, so we can't remove any older tx(s)
 			if len(buffer) == 0 {
+				req.ResponseChan <- 0
 				break
 			}
 

--- a/app/data/pending.go
+++ b/app/data/pending.go
@@ -27,8 +27,6 @@ type PendingPool struct {
 	ListTxsChan       chan ListRequest
 	PubSub            *redis.Client
 	RPC               *rpc.Client
-	LastPruned        time.Time
-	PruneAfter        time.Duration
 }
 
 // Start - This method is supposed to be run as an independent
@@ -661,7 +659,7 @@ func (p *PendingPool) PublishAdded(ctx context.Context, pubsub *redis.Client, ms
 
 // Remove - Removes already existing tx from pending tx pool
 // denoting it has been mined i.e. confirmed/ dropped ( possible too )
-func (p *PendingPool) Remove(ctx context.Context, pubsub *redis.Client, txStat *TxStatus) bool {
+func (p *PendingPool) Remove(ctx context.Context, txStat *TxStatus) bool {
 
 	respChan := make(chan bool)
 
@@ -692,7 +690,7 @@ func (p *PendingPool) PublishRemoved(ctx context.Context, pubsub *redis.Client, 
 }
 
 // AddPendings - Update latest pending pool state
-func (p *PendingPool) AddPendings(ctx context.Context, pubsub *redis.Client, txs map[string]map[string]*MemPoolTx) uint64 {
+func (p *PendingPool) AddPendings(ctx context.Context, txs map[string]map[string]*MemPoolTx) uint64 {
 
 	var count uint64
 
@@ -712,7 +710,7 @@ func (p *PendingPool) AddPendings(ctx context.Context, pubsub *redis.Client, txs
 
 // RemoveDroppedAndConfirmed - Given current tx list attempt to remove
 // txs which are dropped/ confirmed
-func (p *PendingPool) RemoveDroppedAndConfirmed(ctx context.Context, pubsub *redis.Client, txs map[string]map[string]*MemPoolTx) uint64 {
+func (p *PendingPool) RemoveDroppedAndConfirmed(ctx context.Context, txs map[string]map[string]*MemPoolTx) uint64 {
 
 	resp := make(chan uint64)
 	p.RemoveTxsChan <- RemoveTxsFromPendingPool{Txs: txs, ResponseChan: resp}

--- a/app/data/pending.go
+++ b/app/data/pending.go
@@ -350,11 +350,6 @@ func (p *PendingPool) DescListTxs() []*MemPoolTx {
 
 }
 
-// ListTxs - Returns all tx(s) present in pending pool, as slice
-func (p *PendingPool) ListTxs() []*MemPoolTx {
-	return p.DescListTxs()
-}
-
 // TopXWithHighGasPrice - Returns only top `X` tx(s) present in pending mempool,
 // where being top is determined by how much gas price paid by tx sender
 func (p *PendingPool) TopXWithHighGasPrice(x uint64) []*MemPoolTx {

--- a/app/data/pending.go
+++ b/app/data/pending.go
@@ -256,6 +256,7 @@ func (p *PendingPool) Prune(ctx context.Context, commChan chan *listen.CaughtTx)
 				break
 			}
 			var expected uint64 = uint64(len(prunables))
+			var startTime time.Time = time.Now().UTC()
 
 			for i := 0; i < int(expected); i++ {
 
@@ -284,7 +285,6 @@ func (p *PendingPool) Prune(ctx context.Context, commChan chan *listen.CaughtTx)
 			var (
 				received           uint64
 				droppedOrConfirmed uint64
-				marked             uint64
 			)
 
 			// Waiting for all workers to finish
@@ -296,12 +296,6 @@ func (p *PendingPool) Prune(ctx context.Context, commChan chan *listen.CaughtTx)
 					// for all to come & then doing it
 					if p.Remove(ctx, v) {
 						droppedOrConfirmed++
-
-						if droppedOrConfirmed > marked && droppedOrConfirmed%10 == 0 {
-							log.Printf("[➖] Removed 10 tx(s) from pending tx pool\n")
-
-							marked = droppedOrConfirmed
-						}
 					}
 
 				}
@@ -312,6 +306,8 @@ func (p *PendingPool) Prune(ctx context.Context, commChan chan *listen.CaughtTx)
 				}
 
 			}
+
+			log.Printf("[➖] Removed %d tx(s) from pending tx pool, in %s\n", droppedOrConfirmed, time.Now().UTC().Sub(startTime))
 
 		}
 

--- a/app/data/pending.go
+++ b/app/data/pending.go
@@ -806,6 +806,24 @@ func (p *PendingPool) Add(ctx context.Context, tx *MemPoolTx) bool {
 
 }
 
+// VerifiedAdd - Before adding tx from queued pool, just check do we
+// really need to add this tx in pending pool i.e. is this tx really
+// pending ?
+func (p *PendingPool) VerifiedAdd(ctx context.Context, tx *MemPoolTx) bool {
+
+	ok, err := tx.IsNonceExhausted(ctx, p.RPC)
+	if err != nil {
+		return false
+	}
+
+	if ok {
+		return false
+	}
+
+	return p.Add(ctx, tx)
+
+}
+
 // PublishAdded - Publish new pending tx pool content ( in messagepack serialized format )
 // to pubsub topic
 func (p *PendingPool) PublishAdded(ctx context.Context, pubsub *redis.Client, msg *MemPoolTx) {

--- a/app/data/pending.go
+++ b/app/data/pending.go
@@ -294,6 +294,8 @@ func (p *PendingPool) Start(ctx context.Context) {
 
 			if tx, ok := p.Transactions[req.Tx]; ok {
 				req.ResponseChan <- tx
+
+				p.Lock.RUnlock()
 				break
 			}
 

--- a/app/data/pool.go
+++ b/app/data/pool.go
@@ -143,19 +143,6 @@ func (m *MemPool) TopXQueuedWithLowGasPrice(x uint64) []*MemPoolTx {
 // Process - Process all current pending & queued tx pool content & populate our in-memory buffer
 func (m *MemPool) Process(ctx context.Context, pending map[string]map[string]*MemPoolTx, queued map[string]map[string]*MemPoolTx) {
 
-	switch m.Queued.RemoveUnstuck(ctx, pending, queued) {
-
-	case EMPTY:
-		log.Printf("[❕] Nothing to prune in queued pool\n")
-	case PRUNING:
-		log.Printf("[❕] Queued pool pruning in progress\n")
-	case SCHEDULED:
-		log.Printf("[🔅] Scheduled queued pool pruning\n")
-	default:
-		log.Printf("[❗️] Unhandled response code detected\n")
-
-	}
-
 	start := time.Now().UTC()
 
 	if addedQ := m.Queued.AddQueued(ctx, queued); addedQ != 0 {

--- a/app/data/pool.go
+++ b/app/data/pool.go
@@ -222,7 +222,7 @@ func (m *MemPool) HandleTxFromPeer(ctx context.Context, pubsub *redis.Client, tx
 
 		// If we don't have it in our state, we'll add it
 		if !exists {
-			status = m.Pending.Add(ctx, pubsub, tx)
+			status = m.Pending.Add(ctx, tx)
 		}
 
 	}

--- a/app/data/pool.go
+++ b/app/data/pool.go
@@ -162,19 +162,6 @@ func (m *MemPool) Process(ctx context.Context, pending map[string]map[string]*Me
 		log.Printf("[➕] Added %d tx(s) to queued tx pool, in %s\n", addedQ, time.Now().UTC().Sub(start))
 	}
 
-	switch m.Pending.RemoveDroppedAndConfirmed(ctx, pending) {
-
-	case EMPTY:
-		log.Printf("[❕] Nothing to prune in pending pool\n")
-	case PRUNING:
-		log.Printf("[❕] Pending pool pruning in progress\n")
-	case SCHEDULED:
-		log.Printf("[🔅] Scheduled pending pool pruning\n")
-	default:
-		log.Printf("[❗️] Unhandled response code detected\n")
-
-	}
-
 	start = time.Now().UTC()
 
 	if addedP := m.Pending.AddPendings(ctx, pending); addedP != 0 {

--- a/app/data/pool.go
+++ b/app/data/pool.go
@@ -155,10 +155,17 @@ func (m *MemPool) Process(ctx context.Context, pending map[string]map[string]*Me
 		log.Printf("[➕] Added %d tx(s) to queued tx pool, in %s\n", addedQ, time.Now().UTC().Sub(start))
 	}
 
-	if m.Pending.RemoveDroppedAndConfirmed(ctx, pending) {
-		log.Printf("[✳︎] Scheduled pending pool pruning\n")
-	} else {
+	switch m.Pending.RemoveDroppedAndConfirmed(ctx, pending) {
+
+	case 0:
+		log.Printf("[❓] Nothing to prune yet\n")
+	case 1:
 		log.Printf("[❕] Pending pool pruning in progress\n")
+	case 2:
+		log.Printf("[✳︎] Scheduled pending pool pruning\n")
+	default:
+		log.Printf("[❗️] Unhandled response code detected\n")
+
 	}
 
 	start = time.Now().UTC()

--- a/app/data/pool.go
+++ b/app/data/pool.go
@@ -145,12 +145,12 @@ func (m *MemPool) Process(ctx context.Context, pending map[string]map[string]*Me
 
 	switch m.Queued.RemoveUnstuck(ctx, pending, queued) {
 
-	case 0:
-		log.Printf("[❓] Nothing to prune yet\n")
-	case 1:
+	case EMPTY:
+		log.Printf("[❕] Nothing to prune in queued pool\n")
+	case PRUNING:
 		log.Printf("[❕] Queued pool pruning in progress\n")
-	case 2:
-		log.Printf("[✳︎] Scheduled queued pool pruning\n")
+	case SCHEDULED:
+		log.Printf("[🔅] Scheduled queued pool pruning\n")
 	default:
 		log.Printf("[❗️] Unhandled response code detected\n")
 
@@ -164,12 +164,12 @@ func (m *MemPool) Process(ctx context.Context, pending map[string]map[string]*Me
 
 	switch m.Pending.RemoveDroppedAndConfirmed(ctx, pending) {
 
-	case 0:
-		log.Printf("[❓] Nothing to prune yet\n")
-	case 1:
+	case EMPTY:
+		log.Printf("[❕] Nothing to prune in pending pool\n")
+	case PRUNING:
 		log.Printf("[❕] Pending pool pruning in progress\n")
-	case 2:
-		log.Printf("[✳︎] Scheduled pending pool pruning\n")
+	case SCHEDULED:
+		log.Printf("[🔅] Scheduled pending pool pruning\n")
 	default:
 		log.Printf("[❗️] Unhandled response code detected\n")
 

--- a/app/data/pool.go
+++ b/app/data/pool.go
@@ -158,12 +158,6 @@ func (m *MemPool) Process(ctx context.Context, rpc *rpc.Client, pubsub *redis.Cl
 
 	start = time.Now().UTC()
 
-	if removedP := m.Pending.RemoveConfirmedAndDropped(ctx, rpc, pubsub, pending); removedP != 0 {
-		log.Printf("[➖] Removed %d confirmed/ dropped tx(s) from pending tx pool, in %s\n", removedP, time.Now().UTC().Sub(start))
-	}
-
-	start = time.Now().UTC()
-
 	if addedP := m.Pending.AddPendings(ctx, pubsub, pending); addedP != 0 {
 		log.Printf("[➕] Added %d tx(s) to pending tx pool, in %s\n", addedP, time.Now().UTC().Sub(start))
 	}

--- a/app/data/pool.go
+++ b/app/data/pool.go
@@ -155,7 +155,11 @@ func (m *MemPool) Process(ctx context.Context, pending map[string]map[string]*Me
 		log.Printf("[➕] Added %d tx(s) to queued tx pool, in %s\n", addedQ, time.Now().UTC().Sub(start))
 	}
 
-	m.Pending.RemoveDroppedAndConfirmed(ctx, pending)
+	if m.Pending.RemoveDroppedAndConfirmed(ctx, pending) {
+		log.Printf("[✳︎] Scheduled pending pool pruning\n")
+	} else {
+		log.Printf("[❕] Pending pool pruning in progress\n")
+	}
 
 	start = time.Now().UTC()
 

--- a/app/data/pool.go
+++ b/app/data/pool.go
@@ -155,11 +155,7 @@ func (m *MemPool) Process(ctx context.Context, pending map[string]map[string]*Me
 		log.Printf("[➕] Added %d tx(s) to queued tx pool, in %s\n", addedQ, time.Now().UTC().Sub(start))
 	}
 
-	start = time.Now().UTC()
-
-	if removedP := m.Pending.RemoveDroppedAndConfirmed(ctx, pending); removedP != 0 {
-		log.Printf("[➖] Removed %d tx(s) from pending tx pool, in %s\n", removedP, time.Now().UTC().Sub(start))
-	}
+	m.Pending.RemoveDroppedAndConfirmed(ctx, pending)
 
 	start = time.Now().UTC()
 

--- a/app/data/pool.go
+++ b/app/data/pool.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/go-redis/redis/v8"
 )
 
@@ -142,17 +141,29 @@ func (m *MemPool) TopXQueuedWithLowGasPrice(x uint64) []*MemPoolTx {
 }
 
 // Process - Process all current pending & queued tx pool content & populate our in-memory buffer
-func (m *MemPool) Process(ctx context.Context, rpc *rpc.Client, pubsub *redis.Client, pending map[string]map[string]*MemPoolTx, queued map[string]map[string]*MemPoolTx) {
+func (m *MemPool) Process(ctx context.Context, pending map[string]map[string]*MemPoolTx, queued map[string]map[string]*MemPoolTx) {
 
 	start := time.Now().UTC()
 
-	if addedQ := m.Queued.AddQueued(ctx, pubsub, queued); addedQ != 0 {
+	if removedQ := m.Queued.RemoveUnstuck(ctx, pending, queued); removedQ != 0 {
+		log.Printf("[➖] Removed %d tx(s) from queued tx pool, in %s\n", removedQ, time.Now().UTC().Sub(start))
+	}
+
+	start = time.Now().UTC()
+
+	if addedQ := m.Queued.AddQueued(ctx, queued); addedQ != 0 {
 		log.Printf("[➕] Added %d tx(s) to queued tx pool, in %s\n", addedQ, time.Now().UTC().Sub(start))
 	}
 
 	start = time.Now().UTC()
 
-	if addedP := m.Pending.AddPendings(ctx, pubsub, pending); addedP != 0 {
+	if removedP := m.Pending.RemoveDroppedAndConfirmed(ctx, pending); removedP != 0 {
+		log.Printf("[➖] Removed %d tx(s) from pending tx pool, in %s\n", removedP, time.Now().UTC().Sub(start))
+	}
+
+	start = time.Now().UTC()
+
+	if addedP := m.Pending.AddPendings(ctx, pending); addedP != 0 {
 		log.Printf("[➕] Added %d tx(s) to pending tx pool, in %s\n", addedP, time.Now().UTC().Sub(start))
 	}
 
@@ -187,7 +198,7 @@ func (m *MemPool) HandleTxFromPeer(ctx context.Context, pubsub *redis.Client, tx
 		// this tx got dropped, we'll try to update our state
 		// same as our peer did
 		if exists {
-			status = m.Pending.Remove(ctx, pubsub, &TxStatus{Hash: tx.Hash, Status: DROPPED})
+			status = m.Pending.Remove(ctx, &TxStatus{Hash: tx.Hash, Status: DROPPED})
 		}
 
 	case "confirmed":
@@ -196,14 +207,14 @@ func (m *MemPool) HandleTxFromPeer(ctx context.Context, pubsub *redis.Client, tx
 		// this tx got confirmed, we'll try to update our state
 		// same as our peer did
 		if exists {
-			status = m.Pending.Remove(ctx, pubsub, &TxStatus{Hash: tx.Hash, Status: CONFIRMED})
+			status = m.Pending.Remove(ctx, &TxStatus{Hash: tx.Hash, Status: CONFIRMED})
 		}
 
 	case "queued":
 
 		// If we don't have it in our state, we'll add it
 		if !exists {
-			status = m.Queued.Add(ctx, pubsub, tx)
+			status = m.Queued.Add(ctx, tx)
 		}
 
 	case "pending":

--- a/app/data/pool.go
+++ b/app/data/pool.go
@@ -146,12 +146,6 @@ func (m *MemPool) Process(ctx context.Context, rpc *rpc.Client, pubsub *redis.Cl
 
 	start := time.Now().UTC()
 
-	if removedQ := m.Queued.RemoveUnstuck(ctx, rpc, pubsub, m.Pending, pending, queued); removedQ != 0 {
-		log.Printf("[➖] Removed %d unstuck tx(s) from queued tx pool, in %s\n", removedQ, time.Now().UTC().Sub(start))
-	}
-
-	start = time.Now().UTC()
-
 	if addedQ := m.Queued.AddQueued(ctx, pubsub, queued); addedQ != 0 {
 		log.Printf("[➕] Added %d tx(s) to queued tx pool, in %s\n", addedQ, time.Now().UTC().Sub(start))
 	}

--- a/app/data/queued.go
+++ b/app/data/queued.go
@@ -353,11 +353,6 @@ func (q *QueuedPool) DescListTxs() []*MemPoolTx {
 
 }
 
-// ListTxs - Returns all tx(s) present in queued pool, as slice
-func (q *QueuedPool) ListTxs() []*MemPoolTx {
-	return q.DescListTxs()
-}
-
 // TopXWithHighGasPrice - Returns only top `X` tx(s) present in queued mempool,
 // where being top is determined by how much gas price paid by tx sender
 func (q *QueuedPool) TopXWithHighGasPrice(x uint64) []*MemPoolTx {

--- a/app/data/queued.go
+++ b/app/data/queued.go
@@ -3,6 +3,7 @@ package data
 import (
 	"context"
 	"log"
+	"runtime"
 	"sync"
 	"time"
 
@@ -407,7 +408,7 @@ func (q *QueuedPool) DuplicateTxs(hash common.Hash) []*MemPoolTx {
 
 	// Attempting to concurrently checking which txs are duplicate
 	// of a given tx hash
-	wp := workerpool.New(config.GetConcurrencyFactor())
+	wp := workerpool.New(runtime.NumCPU())
 
 	for i := 0; i < len(txs); i++ {
 
@@ -502,7 +503,7 @@ func (q *QueuedPool) SentFrom(address common.Address) []*MemPoolTx {
 	commChan := make(chan *MemPoolTx, txCount)
 	result := make([]*MemPoolTx, 0, txCount)
 
-	wp := workerpool.New(config.GetConcurrencyFactor())
+	wp := workerpool.New(runtime.NumCPU())
 
 	for i := 0; i < len(txs); i++ {
 
@@ -563,7 +564,7 @@ func (q *QueuedPool) SentTo(address common.Address) []*MemPoolTx {
 	commChan := make(chan *MemPoolTx, txCount)
 	result := make([]*MemPoolTx, 0, txCount)
 
-	wp := workerpool.New(config.GetConcurrencyFactor())
+	wp := workerpool.New(runtime.NumCPU())
 
 	for i := 0; i < len(txs); i++ {
 
@@ -624,7 +625,7 @@ func (q *QueuedPool) OlderThanX(x time.Duration) []*MemPoolTx {
 	commChan := make(chan *MemPoolTx, txCount)
 	result := make([]*MemPoolTx, 0, txCount)
 
-	wp := workerpool.New(config.GetConcurrencyFactor())
+	wp := workerpool.New(runtime.NumCPU())
 
 	for i := 0; i < len(txs); i++ {
 
@@ -685,7 +686,7 @@ func (q *QueuedPool) FresherThanX(x time.Duration) []*MemPoolTx {
 	commChan := make(chan *MemPoolTx, txCount)
 	result := make([]*MemPoolTx, 0, txCount)
 
-	wp := workerpool.New(config.GetConcurrencyFactor())
+	wp := workerpool.New(runtime.NumCPU())
 
 	for i := 0; i < len(txs); i++ {
 

--- a/app/data/queued.go
+++ b/app/data/queued.go
@@ -302,7 +302,10 @@ func (q *QueuedPool) Start(ctx context.Context) {
 				// -- Safe reading starting here
 				q.Lock.RLock()
 
-				req.ResponseChan <- q.AscTxsByGasPrice.get()
+				copied := make([]*MemPoolTx, q.AscTxsByGasPrice.len())
+				copy(copied, q.AscTxsByGasPrice.get())
+
+				req.ResponseChan <- copied
 
 				q.Lock.RUnlock()
 				// -- ending here
@@ -313,7 +316,10 @@ func (q *QueuedPool) Start(ctx context.Context) {
 				// -- Safe reading starting here
 				q.Lock.RLock()
 
-				req.ResponseChan <- q.DescTxsByGasPrice.get()
+				copied := make([]*MemPoolTx, q.DescTxsByGasPrice.len())
+				copy(copied, q.DescTxsByGasPrice.get())
+
+				req.ResponseChan <- copied
 
 				q.Lock.RUnlock()
 				// -- ending here

--- a/app/data/queued.go
+++ b/app/data/queued.go
@@ -471,7 +471,7 @@ func (q *QueuedPool) RemoveUnstuck(ctx context.Context, rpc *rpc.Client, pubsub 
 
 		// pushing unstuck tx into pending pool
 		// because now it's eligible for it
-		if !pendingPool.Add(ctx, pubsub, tx) {
+		if !pendingPool.Add(ctx, tx) {
 			log.Printf("[❗️] Failed to push unstuck tx into pending pool\n")
 		}
 

--- a/app/data/queued.go
+++ b/app/data/queued.go
@@ -231,10 +231,9 @@ func (q *QueuedPool) Start(ctx context.Context) {
 						unstuck++
 
 						// Pushing unstuck tx into pending pool
-						// because now it's eligible for it
-						if !q.PendingPool.Add(ctx, tx) {
-							log.Printf("[❗️] Failed to push unstuck tx into pending pool, already done\n")
-						}
+						// because now it's eligible for it, but it
+						// may be already present in pool
+						q.PendingPool.Add(ctx, tx)
 
 					}
 

--- a/app/data/queued.go
+++ b/app/data/queued.go
@@ -281,6 +281,7 @@ func (q *QueuedPool) Prune(ctx context.Context) {
 			var (
 				received uint64
 				unstuck  uint64
+				marked   uint64
 			)
 
 			// Waiting for all go routines to finish
@@ -304,8 +305,10 @@ func (q *QueuedPool) Prune(ctx context.Context) {
 					// may be already present in pool
 					q.PendingPool.Add(ctx, tx)
 
-					if unstuck%10 == 0 {
+					if unstuck > marked && unstuck%10 == 0 {
 						log.Printf("[➖] Removed 10 tx(s) from queued tx pool\n")
+
+						marked = unstuck
 					}
 
 				}

--- a/app/data/queued.go
+++ b/app/data/queued.go
@@ -326,6 +326,11 @@ func (q *QueuedPool) Prune(ctx context.Context) {
 			// reached this point
 			wp.Stop()
 
+			// Only if non-zero number of txs are pruned, show them
+			if unstuck == 0 {
+				break
+			}
+
 			log.Printf("[➖] Removed %d tx(s) from queued tx pool, in %s\n", unstuck, time.Now().UTC().Sub(start))
 
 		}

--- a/app/data/queued.go
+++ b/app/data/queued.go
@@ -307,25 +307,56 @@ func (q *QueuedPool) DuplicateTxs(hash common.Hash) []*MemPoolTx {
 		return nil
 	}
 
+	// Attempting to concurrently checking which txs are duplicate
+	// of a given tx hash
+	wp := workerpool.New(config.GetConcurrencyFactor())
+
 	txs := q.DescListTxs()
-	result := make([]*MemPoolTx, 0, len(txs))
+	txCount := uint64(len(txs))
+	commChan := make(chan *MemPoolTx, txCount)
+	result := make([]*MemPoolTx, 0, txCount)
 
 	for i := 0; i < len(txs); i++ {
 
-		// First checking if tx under radar is the one for which
-		// we're finding duplicate tx(s). If yes, we will move to next one
-		//
-		// Now we can check whether current tx under radar is having same nonce
-		// and sender address, as of target tx ( for which we had txHash, as input )
-		// or not
-		//
-		// If yes, we'll include it considerable duplicate tx list, for given
-		// txHash
-		if txs[i].IsDuplicateOf(targetTx) {
-			result = append(result, txs[i])
+		func(tx *MemPoolTx) {
+
+			wp.Submit(func() {
+
+				if tx.IsDuplicateOf(targetTx) {
+					commChan <- tx
+					return
+				}
+
+				commChan <- nil
+
+			})
+
+		}(txs[i])
+
+	}
+
+	var received uint64
+	mustReceive := txCount
+
+	// Waiting for all go routines to finish
+	for v := range commChan {
+
+		if v != nil {
+			result = append(result, v)
+		}
+
+		received++
+		if received >= mustReceive {
+			break
 		}
 
 	}
+
+	// This call is irrelevant here, probably, but still being made
+	//
+	// Because all workers have exited, otherwise we could have never
+	// reached this point
+	wp.Stop()
 
 	return result
 

--- a/app/data/queued.go
+++ b/app/data/queued.go
@@ -301,6 +301,14 @@ func (q *QueuedPool) Start(ctx context.Context) {
 				// -- Safe reading starting here
 				q.Lock.RLock()
 
+				// If empty, just return nil
+				if q.AscTxsByGasPrice.len() == 0 {
+					req.ResponseChan <- nil
+
+					q.Lock.RUnlock()
+					break
+				}
+
 				copied := make([]*MemPoolTx, q.AscTxsByGasPrice.len())
 				copy(copied, q.AscTxsByGasPrice.get())
 
@@ -314,6 +322,14 @@ func (q *QueuedPool) Start(ctx context.Context) {
 			if req.Order == DESC {
 				// -- Safe reading starting here
 				q.Lock.RLock()
+
+				// If empty, just return nil
+				if q.DescTxsByGasPrice.len() == 0 {
+					req.ResponseChan <- nil
+
+					q.Lock.RUnlock()
+					break
+				}
 
 				copied := make([]*MemPoolTx, q.DescTxsByGasPrice.len())
 				copy(copied, q.DescTxsByGasPrice.get())
@@ -380,14 +396,18 @@ func (q *QueuedPool) DuplicateTxs(hash common.Hash) []*MemPoolTx {
 		return nil
 	}
 
-	// Attempting to concurrently checking which txs are duplicate
-	// of a given tx hash
-	wp := workerpool.New(config.GetConcurrencyFactor())
-
 	txs := q.DescListTxs()
+	if txs == nil {
+		return nil
+	}
+
 	txCount := uint64(len(txs))
 	commChan := make(chan *MemPoolTx, txCount)
 	result := make([]*MemPoolTx, 0, txCount)
+
+	// Attempting to concurrently checking which txs are duplicate
+	// of a given tx hash
+	wp := workerpool.New(config.GetConcurrencyFactor())
 
 	for i := 0; i < len(txs); i++ {
 
@@ -473,12 +493,16 @@ func (q *QueuedPool) TopXWithLowGasPrice(x uint64) []*MemPoolTx {
 // specified address
 func (q *QueuedPool) SentFrom(address common.Address) []*MemPoolTx {
 
-	wp := workerpool.New(config.GetConcurrencyFactor())
-
 	txs := q.DescListTxs()
+	if txs == nil {
+		return nil
+	}
+
 	txCount := uint64(len(txs))
 	commChan := make(chan *MemPoolTx, txCount)
 	result := make([]*MemPoolTx, 0, txCount)
+
+	wp := workerpool.New(config.GetConcurrencyFactor())
 
 	for i := 0; i < len(txs); i++ {
 
@@ -530,12 +554,16 @@ func (q *QueuedPool) SentFrom(address common.Address) []*MemPoolTx {
 // specified address
 func (q *QueuedPool) SentTo(address common.Address) []*MemPoolTx {
 
-	wp := workerpool.New(config.GetConcurrencyFactor())
-
 	txs := q.DescListTxs()
+	if txs == nil {
+		return nil
+	}
+
 	txCount := uint64(len(txs))
 	commChan := make(chan *MemPoolTx, txCount)
 	result := make([]*MemPoolTx, 0, txCount)
+
+	wp := workerpool.New(config.GetConcurrencyFactor())
 
 	for i := 0; i < len(txs); i++ {
 
@@ -587,12 +615,16 @@ func (q *QueuedPool) SentTo(address common.Address) []*MemPoolTx {
 // living in mempool for more than or equals to `X` time unit
 func (q *QueuedPool) OlderThanX(x time.Duration) []*MemPoolTx {
 
-	wp := workerpool.New(config.GetConcurrencyFactor())
-
 	txs := q.DescListTxs()
+	if txs == nil {
+		return nil
+	}
+
 	txCount := uint64(len(txs))
 	commChan := make(chan *MemPoolTx, txCount)
 	result := make([]*MemPoolTx, 0, txCount)
+
+	wp := workerpool.New(config.GetConcurrencyFactor())
 
 	for i := 0; i < len(txs); i++ {
 
@@ -644,12 +676,16 @@ func (q *QueuedPool) OlderThanX(x time.Duration) []*MemPoolTx {
 // living in mempool for less than or equals to `X` time unit
 func (q *QueuedPool) FresherThanX(x time.Duration) []*MemPoolTx {
 
-	wp := workerpool.New(config.GetConcurrencyFactor())
-
 	txs := q.DescListTxs()
+	if txs == nil {
+		return nil
+	}
+
 	txCount := uint64(len(txs))
 	commChan := make(chan *MemPoolTx, txCount)
 	result := make([]*MemPoolTx, 0, txCount)
+
+	wp := workerpool.New(config.GetConcurrencyFactor())
 
 	for i := 0; i < len(txs); i++ {
 

--- a/app/data/queued.go
+++ b/app/data/queued.go
@@ -140,9 +140,7 @@ func (q *QueuedPool) Start(ctx context.Context) {
 						yes, err := tx.IsUnstuck(ctx, q.RPC)
 						if err != nil {
 
-							log.Printf("[❗️] Failed to check if tx unstuck : %s\n", err.Error())
-
-							commChan <- &TxStatus{Hash: tx.Hash, Status: UNSTUCK}
+							commChan <- &TxStatus{Hash: tx.Hash, Status: STUCK}
 							return
 
 						}

--- a/app/data/queued.go
+++ b/app/data/queued.go
@@ -159,10 +159,10 @@ func (q *QueuedPool) Start(ctx context.Context) {
 
 			}
 
-			buffer := make([]common.Hash, 0, q.Count())
+			buffer := make([]common.Hash, 0, txCount)
 
 			var received uint64
-			mustReceive := q.Count()
+			mustReceive := txCount
 
 			// Waiting for all go routines to finish
 			for v := range commChan {

--- a/app/data/queued.go
+++ b/app/data/queued.go
@@ -250,8 +250,6 @@ func (q *QueuedPool) Prune(ctx context.Context) {
 			if txs == nil {
 				break
 			}
-			txCount := uint64(len(txs))
-			commChan := make(chan *TxStatus, txCount)
 
 			for i := 0; i < len(txs); i++ {
 
@@ -264,15 +262,15 @@ func (q *QueuedPool) Prune(ctx context.Context) {
 						yes, err := tx.IsUnstuck(ctx, q.RPC)
 						if err != nil {
 
-							commChan <- &TxStatus{Hash: tx.Hash, Status: STUCK}
+							internalChan <- &TxStatus{Hash: tx.Hash, Status: STUCK}
 							return
 
 						}
 
 						if yes {
-							commChan <- &TxStatus{Hash: tx.Hash, Status: UNSTUCK}
+							internalChan <- &TxStatus{Hash: tx.Hash, Status: UNSTUCK}
 						} else {
-							commChan <- &TxStatus{Hash: tx.Hash, Status: STUCK}
+							internalChan <- &TxStatus{Hash: tx.Hash, Status: STUCK}
 						}
 
 					})

--- a/app/data/queued.go
+++ b/app/data/queued.go
@@ -400,16 +400,54 @@ func (q *QueuedPool) TopXWithLowGasPrice(x uint64) []*MemPoolTx {
 // specified address
 func (q *QueuedPool) SentFrom(address common.Address) []*MemPoolTx {
 
+	wp := workerpool.New(config.GetConcurrencyFactor())
+
 	txs := q.DescListTxs()
-	result := make([]*MemPoolTx, 0, len(txs))
+	txCount := uint64(len(txs))
+	commChan := make(chan *MemPoolTx, txCount)
+	result := make([]*MemPoolTx, 0, txCount)
 
 	for i := 0; i < len(txs); i++ {
 
-		if txs[i].IsSentFrom(address) {
-			result = append(result, txs[i])
+		func(tx *MemPoolTx) {
+
+			wp.Submit(func() {
+
+				if txs[i].IsSentFrom(address) {
+					commChan <- tx
+					return
+				}
+
+				commChan <- nil
+
+			})
+
+		}(txs[i])
+
+	}
+
+	var received uint64
+	mustReceive := txCount
+
+	// Waiting for all go routines to finish
+	for v := range commChan {
+
+		if v != nil {
+			result = append(result, v)
+		}
+
+		received++
+		if received >= mustReceive {
+			break
 		}
 
 	}
+
+	// This call is irrelevant here, probably, but still being made
+	//
+	// Because all workers have exited, otherwise we could have never
+	// reached this point
+	wp.Stop()
 
 	return result
 

--- a/app/data/queued.go
+++ b/app/data/queued.go
@@ -300,10 +300,9 @@ func (q *QueuedPool) Prune(ctx context.Context) {
 
 					unstuck++
 
-					// Pushing unstuck tx into pending pool
-					// because now it's eligible for it, but it
-					// may be already present in pool
-					q.PendingPool.Add(ctx, tx)
+					// Just check whether we need to add this tx into pending
+					// pool first, if not required, we're not adding it
+					q.PendingPool.VerifiedAdd(ctx, tx)
 
 					if unstuck > marked && unstuck%10 == 0 {
 						log.Printf("[➖] Removed 10 tx(s) from queued tx pool\n")

--- a/app/data/resource.go
+++ b/app/data/resource.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/go-redis/redis/v8"
 )
@@ -13,6 +14,7 @@ import (
 // Needs to be released carefully when shutting down
 type Resource struct {
 	RPCClient *rpc.Client
+	WSClient  *ethclient.Client
 	Pool      *MemPool
 	Redis     *redis.Client
 	StartedAt time.Time
@@ -24,6 +26,7 @@ type Resource struct {
 func (r *Resource) Release() {
 
 	r.RPCClient.Close()
+	r.WSClient.Close()
 	if err := r.Redis.Close(); err != nil {
 		log.Printf("[❗️] Failed to close redis client : %s\n", err.Error())
 	}

--- a/app/data/tx.go
+++ b/app/data/tx.go
@@ -284,6 +284,16 @@ func (m *MemPoolTx) ToGraphQL() *model.MemPoolTx {
 
 		}
 
+	default:
+		// handle situation when deserilisation didn't work
+		// properly
+		break
+
+	}
+
+	// In that case, simply return
+	if gqlTx == nil {
+		return nil
 	}
 
 	if m.To != nil {

--- a/app/data/tx.go
+++ b/app/data/tx.go
@@ -51,6 +51,14 @@ func (m *MemPoolTx) IsDuplicateOf(tx *MemPoolTx) bool {
 
 }
 
+// IsLowerNonce - Objective is to find out whether `m` has same
+// of lower nonce than `tx`
+func (m *MemPoolTx) IsLowerNonce(tx *MemPoolTx) bool {
+
+	return m.Hash != tx.Hash && m.From == tx.From && m.Nonce <= tx.Nonce
+
+}
+
 // IsSentFrom - Checks whether this tx was sent from specified address
 // or not
 func (m *MemPoolTx) IsSentFrom(address common.Address) bool {

--- a/app/data/tx.go
+++ b/app/data/tx.go
@@ -318,12 +318,12 @@ func (m *MemPoolTx) ToGraphQL() *model.MemPoolTx {
 
 }
 
-var (
-	STUCK     = 1
-	UNSTUCK   = 2
-	PENDING   = 3
-	CONFIRMED = 4
-	DROPPED   = 5
+const (
+	STUCK = iota + 1
+	UNSTUCK
+	PENDING
+	CONFIRMED
+	DROPPED
 )
 
 // TxStatus - When ever multiple go routines need to

--- a/app/graph/util.go
+++ b/app/graph/util.go
@@ -273,7 +273,15 @@ func ListenToMessages(ctx context.Context, pubsub *redis.PubSub, topics []string
 					// data to deliver it to client in expected format
 					message := UnmarshalPubSubMessage([]byte(m.Payload))
 					if message != nil && pubCriteria(message, params...) {
-						comm <- message.ToGraphQL()
+
+						// Only publish non-nil data i.e. if (de)-serialisation
+						// fails some how, it's better to send nothing, rather than
+						// sending client `nil`
+						sendable := message.ToGraphQL()
+						if sendable != nil {
+							comm <- sendable
+						}
+
 					}
 
 				default:

--- a/app/listen/header.go
+++ b/app/listen/header.go
@@ -33,6 +33,7 @@ func SubscribeHead(ctx context.Context, client *ethclient.Client, commChan chan 
 		select {
 
 		case <-ctx.Done():
+			subs.Unsubscribe()
 			return
 
 		case err := <-subs.Err():
@@ -46,6 +47,8 @@ func SubscribeHead(ctx context.Context, client *ethclient.Client, commChan chan 
 				log.Printf("[!] Failed to fetch block : %d\n", header.Number.Uint64())
 				break
 			}
+
+			log.Printf("🧱 Block %d mined with %d tx(s)\n", header.Number.Uint64(), len(block.Transactions()))
 
 			for _, tx := range block.Transactions() {
 

--- a/app/listen/header.go
+++ b/app/listen/header.go
@@ -1,0 +1,65 @@
+package listen
+
+import (
+	"context"
+	"log"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+// CaughtTx - Tx caught by block head subscriber, passed to
+// pending pool watcher, so that it can prune its state
+type CaughtTx struct {
+	Hash  common.Hash
+	Nonce uint64
+}
+
+// SubscribeHead - Subscribe to block headers & as soon as new block gets mined
+// its txs are picked up & published on a go channel, which will be listened
+// to by pending pool watcher, so that it can prune its state
+func SubscribeHead(ctx context.Context, client *ethclient.Client, commChan chan *CaughtTx) {
+
+	headerChan := make(chan *types.Header, 1)
+	subs, err := client.SubscribeNewHead(ctx, headerChan)
+	if err != nil {
+		log.Printf("[!] Failed to subscribe to block headers : %s\n", err.Error())
+		return
+	}
+
+	for {
+
+		select {
+
+		case <-ctx.Done():
+			return
+
+		case err := <-subs.Err():
+			log.Printf("[!] Block header subscription failed : %s\n", err.Error())
+			return
+
+		case header := <-headerChan:
+
+			block, err := client.BlockByNumber(ctx, header.Number)
+			if err != nil {
+				log.Printf("[!] Failed to fetch block : %d\n", header.Number.Uint64())
+				break
+			}
+
+			for _, tx := range block.Transactions() {
+
+				// Hopefully pending pool watcher will read this
+				// & prune its state
+				commChan <- &CaughtTx{
+					Hash:  tx.Hash(),
+					Nonce: tx.Nonce(),
+				}
+
+			}
+
+		}
+
+	}
+
+}

--- a/app/listen/header.go
+++ b/app/listen/header.go
@@ -28,7 +28,7 @@ func SubscribeHead(ctx context.Context, client *ethclient.Client, commChan chan 
 	headerChan := make(chan *types.Header, 1)
 	subs, err := client.SubscribeNewHead(ctx, headerChan)
 	if err != nil {
-		log.Printf("[!] Failed to subscribe to block headers : %s\n", err.Error())
+		log.Printf("❗️ Failed to subscribe to block headers : %s\n", err.Error())
 		return
 	}
 
@@ -41,14 +41,14 @@ func SubscribeHead(ctx context.Context, client *ethclient.Client, commChan chan 
 			return
 
 		case err := <-subs.Err():
-			log.Printf("[!] Block header subscription failed : %s\n", err.Error())
+			log.Printf("❗️ Block header subscription failed : %s\n", err.Error())
 			return
 
 		case header := <-headerChan:
 
-			block, err := client.BlockByNumber(ctx, header.Number)
+			block, err := client.BlockByHash(ctx, header.Hash())
 			if err != nil {
-				log.Printf("[!] Failed to fetch block : %d\n", header.Number.Uint64())
+				log.Printf("❗️ Failed to fetch block : %d\n", header.Number.Uint64())
 				break
 			}
 

--- a/app/mempool/poll.go
+++ b/app/mempool/poll.go
@@ -42,7 +42,7 @@ func PollTxPoolContent(ctx context.Context, res *data.Resource, comm chan struct
 		}
 
 		// Process current tx pool content
-		res.Pool.Process(ctx, res.RPCClient, res.Redis, result["pending"], result["queued"])
+		res.Pool.Process(ctx, result["pending"], result["queued"])
 		res.Pool.Stat(start)
 
 		// Sleep for desired amount of time & get to work again


### PR DESCRIPTION
## why ?

- Currently state management is done using RW mutex based synchronisation primitives [ **for keeping concurrent safety** ]
- We can improve performance & avoid lock contention issue by moving to channel based synchronisation primitives [ **which are cheap & concurrent safe** ]
- Move both pool implementation(s) to 👆 mentioned kind
  - [x] Pending Pool
  - [x] Queued Pool
 - Use configurable lazy pruning of state, for better performance, because pruning is **not** cheap
   - [x] Non-Blocking
   - [x] Asynchronous
- Subscribing to block headers & pruning pending pool as soon as we find some prunable txs ✅

**WIP**