### PR TITLE
Track slowly propagated tx(s)

### DIFF
--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -108,7 +108,7 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 	// queued pool also gets notified & gets to update state if required
 	alreadyInPendingPoolChan := make(chan *data.MemPoolTx, 4096)
 	inPendingPoolChan := make(chan *data.MemPoolTx, 4096)
-	lastSeenBlockChan := make(chan uint64, 1)
+	lastSeenBlockChan := make(chan uint64, 16)
 
 	// initialising pending pool
 	pendingPool := &data.PendingPool{

--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -182,6 +182,7 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 	// Listens for new block headers & informs 👆 (a) for pruning
 	// txs which can be/ need to be
 	go listen.SubscribeHead(ctx, wsClient, caughtTxsChan, lastSeenBlockChan)
+	go data.TrackNotFoundTxs(ctx, inPendingPoolChan, notFoundTxsChan, caughtTxsChan)
 
 	// Passed this mempool handle to graphql query resolver
 	if err := graph.InitMemPool(pool); err != nil {

--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -164,6 +164,7 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 	// Block head listener & pending pool pruner
 	// talks over this buffered channel
 	caughtTxsChan := make(chan listen.CaughtTxs, 16)
+	notFoundTxsChan := make(chan listen.CaughtTxs, 16)
 	confirmedTxsChan := make(chan data.ConfirmedTx, 4096)
 
 	// Starting pool life cycle manager go routine
@@ -172,7 +173,7 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 	//
 	// After that this pool will also let (b) know that it can
 	// update state of txs, which have become unstuck
-	go pool.Pending.Prune(ctx, caughtTxsChan, confirmedTxsChan)
+	go pool.Pending.Prune(ctx, caughtTxsChan, confirmedTxsChan, notFoundTxsChan)
 	go pool.Queued.Start(ctx)
 	// (b)
 	go pool.Queued.Prune(ctx, confirmedTxsChan, alreadyInPendingPoolChan)

--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -107,6 +107,7 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 	// & queued pool, so that when new tx gets added into pending pool
 	// queued pool also gets notified & gets to update state if required
 	alreadyInPendingPoolChan := make(chan *data.MemPoolTx, 4096)
+	inPendingPoolChan := make(chan *data.MemPoolTx, 4096)
 	lastSeenBlockChan := make(chan uint64, 1)
 
 	// initialising pending pool
@@ -124,6 +125,7 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 		AddFromQueuedPoolChan:    make(chan data.AddRequest, 1),
 		RemoveTxChan:             make(chan data.RemoveRequest, 1),
 		AlreadyInPendingPoolChan: alreadyInPendingPoolChan,
+		InPendingPoolChan:        inPendingPoolChan,
 		TxExistsChan:             make(chan data.ExistsRequest, 1),
 		GetTxChan:                make(chan data.GetRequest, 1),
 		CountTxsChan:             make(chan data.CountRequest, 1),

--- a/app/data/not_found_txs.go
+++ b/app/data/not_found_txs.go
@@ -1,0 +1,61 @@
+package data
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/itzmeanjan/harmony/app/listen"
+)
+
+// AlreadyMinedTx - Pending pool pruner to be informed about some tx
+// it considers as pending, is actually mined, some time, which pool missed
+// because tx was added into pool, after block was mined, due to some
+// unexpected network propagation delay
+type AlreadyMinedTx struct {
+	Hash  common.Hash
+	Nonce uint64
+}
+
+// TrackNotFoundTxs - Those tx(s) which are found to be mined before actual pending tx is added
+// into mempool, are kept track of here & pending pool pruner is informed about it, when it's found
+// to be joining mempool, in some time future.
+func TrackNotFoundTxs(ctx context.Context, inPendingPoolChan <-chan *MemPoolTx, notFoundTxsChan <-chan listen.CaughtTxs, alreadyMinedTxChan chan<- AlreadyMinedTx) {
+
+	// Yes, for faster lookup, it's kept this
+	keeper := make(map[common.Hash]*listen.CaughtTx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case tx := <-inPendingPoolChan:
+			// Just learnt about new tx which is considered to be pending
+			// & added into pool, but this tx is mined in some previous block
+			// which we've kept track of here in `keeper` structure
+			//
+			// We're letting pending pool pruner know, it must act in declaring this tx
+			// to be mined
+
+			if kept, ok := keeper[tx.Hash]; ok {
+				alreadyMinedTxChan <- AlreadyMinedTx{Hash: kept.Hash, Nonce: kept.Nonce}
+				delete(keeper, tx.Hash)
+			}
+
+		case txs := <-notFoundTxsChan:
+			// New block was mined with some txs
+			// which were not found in pending pool then,
+			// which are being kept track of here
+			//
+			// To be used for letting pending pool know
+			// some newly added pending pool tx is actually mined
+			// in some later date
+
+			for i := 0; i < len(txs); i++ {
+				keeper[txs[i].Hash] = txs[i]
+			}
+
+		}
+	}
+
+}

--- a/app/data/not_found_txs.go
+++ b/app/data/not_found_txs.go
@@ -7,19 +7,10 @@ import (
 	"github.com/itzmeanjan/harmony/app/listen"
 )
 
-// AlreadyMinedTx - Pending pool pruner to be informed about some tx
-// it considers as pending, is actually mined, some time, which pool missed
-// because tx was added into pool, after block was mined, due to some
-// unexpected network propagation delay
-type AlreadyMinedTx struct {
-	Hash  common.Hash
-	Nonce uint64
-}
-
 // TrackNotFoundTxs - Those tx(s) which are found to be mined before actual pending tx is added
 // into mempool, are kept track of here & pending pool pruner is informed about it, when it's found
 // to be joining mempool, in some time future.
-func TrackNotFoundTxs(ctx context.Context, inPendingPoolChan <-chan *MemPoolTx, notFoundTxsChan <-chan listen.CaughtTxs, alreadyMinedTxChan chan<- AlreadyMinedTx) {
+func TrackNotFoundTxs(ctx context.Context, inPendingPoolChan <-chan *MemPoolTx, notFoundTxsChan <-chan listen.CaughtTxs, alreadyMinedTxChan chan<- listen.CaughtTxs) {
 
 	// Yes, for faster lookup, it's kept this
 	keeper := make(map[common.Hash]*listen.CaughtTx)
@@ -38,7 +29,7 @@ func TrackNotFoundTxs(ctx context.Context, inPendingPoolChan <-chan *MemPoolTx, 
 			// to be mined
 
 			if kept, ok := keeper[tx.Hash]; ok {
-				alreadyMinedTxChan <- AlreadyMinedTx{Hash: kept.Hash, Nonce: kept.Nonce}
+				alreadyMinedTxChan <- []*listen.CaughtTx{kept}
 				delete(keeper, tx.Hash)
 			}
 

--- a/app/data/pending.go
+++ b/app/data/pending.go
@@ -324,7 +324,7 @@ func (p *PendingPool) Start(ctx context.Context) {
 
 			// Only keep moving forward
 			if p.LastSeenBlock > num {
-				continue
+				break
 			}
 
 			p.LastSeenBlock = num

--- a/app/listen/header.go
+++ b/app/listen/header.go
@@ -25,7 +25,7 @@ type CaughtTxs []*CaughtTx
 // SubscribeHead - Subscribe to block headers & as soon as new block gets mined
 // its txs are picked up & published on a go channel, which will be listened
 // to by pending pool watcher, so that it can prune its state
-func SubscribeHead(ctx context.Context, client *ethclient.Client, commChan chan CaughtTxs, lastSeenBlockChan chan uint64) {
+func SubscribeHead(ctx context.Context, client *ethclient.Client, commChan chan<- CaughtTxs, lastSeenBlockChan chan<- uint64) {
 
 	retryTable := make(map[*big.Int]bool)
 	headerChan := make(chan *types.Header, 64)
@@ -93,7 +93,7 @@ func SubscribeHead(ctx context.Context, client *ethclient.Client, commChan chan 
 }
 
 // ProcessBlock - Fetches all txs present in mined block & passes those to pending pool pruning worker
-func ProcessBlock(ctx context.Context, client *ethclient.Client, number *big.Int, commChan chan CaughtTxs, lastSeenBlockChan chan uint64) bool {
+func ProcessBlock(ctx context.Context, client *ethclient.Client, number *big.Int, commChan chan<- CaughtTxs, lastSeenBlockChan chan<- uint64) bool {
 
 	block, err := client.BlockByNumber(ctx, number)
 	if err != nil {


### PR DESCRIPTION
## Why ?

Some times mempool tx propagation takes more time than usual & mempool tx is received when it's actually mined. I'm going to keep track of which mined txs I couldn't find in pending pool & later time when same tx joins mempool as pending one, I'll let pending pool pruning worker know, this tx is actually mined.

Hopefully solving our problem. 

**Being tested on mainnet now**