### PR TITLE
Supervising Block Header Listener Worker

### DIFF
--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -188,7 +188,7 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 		var died bool
 
 		healthChan := make(chan struct{})
-		go listen.SubscribeHead(ctx, wsClient, caughtTxsChan, lastSeenBlockChan, healthChan)
+		go listen.SubscribeHead(ctx, wsClient, pool.Pending.GetLastSeenBlock().Number, caughtTxsChan, lastSeenBlockChan, healthChan)
 
 		for {
 
@@ -197,7 +197,7 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 				<-time.After(time.Duration(5) * time.Second)
 
 				healthChan = make(chan struct{})
-				go listen.SubscribeHead(ctx, wsClient, caughtTxsChan, lastSeenBlockChan, healthChan)
+				go listen.SubscribeHead(ctx, wsClient, pool.Pending.GetLastSeenBlock().Number, caughtTxsChan, lastSeenBlockChan, healthChan)
 
 				died = false
 			}

--- a/app/listen/header.go
+++ b/app/listen/header.go
@@ -44,7 +44,12 @@ func SubscribeHead(ctx context.Context, client *ethclient.Client, commChan chan<
 			return
 
 		case err := <-subs.Err():
-			log.Printf("❗️ Block header subscription failed : %s\n", err.Error())
+			if err != nil {
+				log.Printf("❗️ Block header subscription failed : %s\n", err.Error())
+			} else {
+				log.Printf("❗️ Block header subscription failed\n")
+			}
+
 			return
 
 		case header := <-headerChan:

--- a/app/listen/header.go
+++ b/app/listen/header.go
@@ -25,7 +25,7 @@ type CaughtTxs []*CaughtTx
 // SubscribeHead - Subscribe to block headers & as soon as new block gets mined
 // its txs are picked up & published on a go channel, which will be listened
 // to by pending pool watcher, so that it can prune its state
-func SubscribeHead(ctx context.Context, client *ethclient.Client, commChan chan<- CaughtTxs, lastSeenBlockChan chan<- uint64) {
+func SubscribeHead(ctx context.Context, client *ethclient.Client, commChan chan<- CaughtTxs, lastSeenBlockChan chan<- uint64, healthChan chan struct{}) {
 
 	retryTable := make(map[*big.Int]bool)
 	headerChan := make(chan *types.Header, 64)
@@ -50,6 +50,8 @@ func SubscribeHead(ctx context.Context, client *ethclient.Client, commChan chan<
 				log.Printf("❗️ Block header subscription failed\n")
 			}
 
+			// Notify supervisor this worker is dying
+			close(healthChan)
 			return
 
 		case header := <-headerChan:


### PR DESCRIPTION
## Why ?

Block header listen go routine can crash due to several reasons, so it's better to handle that by catching when it crashes & spawning new worker which can continue where its previous worker left off.
