### PR TITLE
Reduce overtime memory usage

### DIFF
--- a/app/bootup/bootup.go
+++ b/app/bootup/bootup.go
@@ -114,8 +114,8 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 	pendingPool := &data.PendingPool{
 		Transactions:             make(map[common.Hash]*data.MemPoolTx),
 		TxsFromAddress:           make(map[common.Address]data.TxList),
-		DroppedTxs:               make(map[common.Hash]bool),
-		RemovedTxs:               make(map[common.Hash]bool),
+		DroppedTxs:               make(map[common.Hash]time.Time),
+		RemovedTxs:               make(map[common.Hash]time.Time),
 		AscTxsByGasPrice:         make(data.MemPoolTxsAsc, 0, config.GetPendingPoolSize()),
 		DescTxsByGasPrice:        make(data.MemPoolTxsDesc, 0, config.GetPendingPoolSize()),
 		Done:                     0,
@@ -142,8 +142,8 @@ func SetGround(ctx context.Context, file string) (*data.Resource, error) {
 	queuedPool := &data.QueuedPool{
 		Transactions:      make(map[common.Hash]*data.MemPoolTx),
 		TxsFromAddress:    make(map[common.Address]data.TxList),
-		DroppedTxs:        make(map[common.Hash]bool),
-		RemovedTxs:        make(map[common.Hash]bool),
+		DroppedTxs:        make(map[common.Hash]time.Time),
+		RemovedTxs:        make(map[common.Hash]time.Time),
 		AscTxsByGasPrice:  make(data.MemPoolTxsAsc, 0, config.GetQueuedPoolSize()),
 		DescTxsByGasPrice: make(data.MemPoolTxsDesc, 0, config.GetQueuedPoolSize()),
 		AddTxChan:         make(chan data.AddRequest, 1),

--- a/app/data/pending.go
+++ b/app/data/pending.go
@@ -332,6 +332,36 @@ func (p *PendingPool) Start(ctx context.Context) {
 
 			req <- LastSeenBlock{Number: p.LastSeenBlock, At: p.LastSeenAt}
 
+		case <-time.After(time.Duration(1) * time.Millisecond):
+			// After 1 hour of keeping entries which were previously removed
+			// are now being deleted from memory, so that memory usage for keeping track of
+			// which were removed in past doesn't become a problem for us.
+			//
+			// 1 hour is just a random time period, it can be possibly improved
+			//
+			// Just hoping after 1 hour of last time this tx was seen to be added
+			// into this pool, it has been either dropped/ confirmed, so it won't
+			// be attempted to be added here again
+
+			for k := range p.DroppedTxs {
+
+				if time.Now().UTC().Sub(p.DroppedTxs[k]) > time.Duration(1)*time.Hour {
+					delete(p.DroppedTxs, k)
+				}
+
+			}
+
+		case <-time.After(time.Duration(1) * time.Millisecond):
+			// Read 👆 comment
+
+			for k := range p.RemovedTxs {
+
+				if time.Now().UTC().Sub(p.RemovedTxs[k]) > time.Duration(1)*time.Hour {
+					delete(p.RemovedTxs, k)
+				}
+
+			}
+
 		}
 
 	}

--- a/app/data/queued.go
+++ b/app/data/queued.go
@@ -269,7 +269,7 @@ func (q *QueuedPool) Start(ctx context.Context) {
 			// 1 hour is just a random time period, it can be possibly improved
 			//
 			// Just hoping after 1 hour of last time this tx was seen to be added
-			// into this pool, it has been either dropped/ removed/ unstuck, so it won't
+			// into this pool, it has been either dropped/ confirmed/ unstuck, so it won't
 			// be attempted to be added here again
 
 			for k := range q.DroppedTxs {


### PR DESCRIPTION
## Why ?

Both pending & queued pool keeps track of which tx(s) were removed because they were `dropped`/ `confirmed`/ `unstuck` & this memory usage overtime becomes a problem.

If we keep removing those entries from tracker table which were seen long time back ( > 1 hour ), we can free some memory. 1 hour is just a random number being used, in hope, after 1 hour of last time it was attempted to be added into pool it is probably not there for again added into pool. This may not be true, if RPC node being relied on, doesn't feed us with fresh data.
